### PR TITLE
Fix "Satisfied" appearing twice in the list of default emotions

### DIFF
--- a/src/data/defaultEmotions.ts
+++ b/src/data/defaultEmotions.ts
@@ -31,7 +31,6 @@ export const defaultEmotions: EmotionSection[] = [
 			"attracted",
 			"sentimental",
 			"compassionate",
-			"satisfied",
 			"peaceful",
 			"relieved",
 		],


### PR DESCRIPTION
The second entry is at https://github.com/Alain1405/obsidian-mood-tracker/blob/03a34025f585e193f8eecc71b1a9c539738ba1c8/src/data/defaultEmotions.ts#L11 